### PR TITLE
Bootstrap FastAPI application with Mangum handler

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,6 @@
--r requirements.txt
-
-uvicorn
-python-dotenv
-pytest
-pytest-cov
-httpx
-cfn-lint
+uvicorn==0.52.2
+python-dotenv==1.2.2
+pytest==9.1.1
+pytest-cov==7.1.0
+httpx==0.28.1
+cfn-lint==1.48.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-fastapi
-mangum
-SQLAlchemy
-alembic
-psycopg2-binary
-boto3
+fastapi==0.141.1
+mangum==0.21.0
+SQLAlchemy==2.0.52
+alembic==1.18.4
+psycopg2-binary==2.9.12
+boto3==1.43.70

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, FastAPI
+from mangum import Mangum
+
+app = FastAPI()
+router = APIRouter(prefix="/api")
+
+app.include_router(router=router)
+# Later Routers Here
+
+handler = Mangum(app, lifespan="off")

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,17 @@
+import os
+
 from fastapi import APIRouter, FastAPI
 from mangum import Mangum
 
 app = FastAPI()
 router = APIRouter(prefix="/api")
 
+@router.get("/health")
+def get_health():
+    return "OK"
+
 app.include_router(router=router)
 # Later Routers Here
 
-handler = Mangum(app, lifespan="off")
+api_stage = os.environ.get("API_STAGE")
+handler = Mangum(app, lifespan="off", api_gateway_base_path=f"/{api_stage}" if api_stage else "/")


### PR DESCRIPTION
## Summary
- Add `src/main.py` with a FastAPI app wired to a Mangum handler (lifespan off) for Lambda deployment
- Pin dependency versions in `requirements.txt` and `requirements.dev.txt` for reproducible builds

## Test plan
- [ ] Verify Lambda handler invokes correctly via SAM local or deployed test
- [ ] Confirm `pip install -r requirements.txt` resolves cleanly with pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)